### PR TITLE
Change to use the org root ID

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,5 +59,5 @@ resource "aws_organizations_policy_attachment" "tag_policy_attachment_org" {
   count = var.attach_to_org ? 1 : 0
 
   policy_id = aws_organizations_policy.this.id
-  target_id = data.aws_organizations_organization.org.id
+  target_id = data.aws_organizations_organization.org.roots[0].id
 }


### PR DESCRIPTION
Was pointing at the Org ID which isn't a valid target for a tag policy. Changed to the root ID. The other var allows specific OUs.